### PR TITLE
remove ntp's new method.

### DIFF
--- a/src/core/ntp.rs
+++ b/src/core/ntp.rs
@@ -55,13 +55,6 @@ pub struct Ntp {
 }
 
 impl Ntp {
-    /// New a config form the path
-    #[cfg(test)]
-    pub fn new(path: &str) -> Self {
-        let config = parse_config!(Ntp, path);
-        config.into()
-    }
-
     /// Check the system clock offset overflow the threshold
     pub fn clock_offset_overflow(&self) -> bool {
         let mut offset_overflow = false;


### PR DESCRIPTION
remove the 'new' method, as it is not used any more, neigher in normal code or in test.