### PR TITLE
add more process to snapshot

### DIFF
--- a/src/core/cita_bft.rs
+++ b/src/core/cita_bft.rs
@@ -1589,7 +1589,12 @@ impl Bft {
                         self.proof = BftProof::from(req.get_proof().clone());
                         self.pre_hash = None;
                         self.block_proof = None;
-                        self.change_state_step(req.end_height as usize, 0, Step::PrecommitAuth, true);
+                        self.change_state_step(
+                            req.end_height as usize,
+                            0,
+                            Step::PrecommitAuth,
+                            true,
+                        );
                         self.save_wal_proof(req.end_height as usize);
                     }
 

--- a/src/core/cita_bft.rs
+++ b/src/core/cita_bft.rs
@@ -1589,12 +1589,8 @@ impl Bft {
                         self.proof = BftProof::from(req.get_proof().clone());
                         self.pre_hash = None;
                         self.block_proof = None;
-                        self.height = req.end_height as usize;
-                        self.round = 0;
-                        self.step = Step::PrecommitAuth;
-                        let hi = self.height;
-                        let _ = self.wal_log.set_height(hi);
-                        self.save_wal_proof(hi);
+                        self.change_state_step(req.end_height as usize, 0, Step::PrecommitAuth, true);
+                        self.save_wal_proof(req.end_height as usize);
                     }
 
                     self.set_snapshot(false);
@@ -1801,11 +1797,6 @@ impl Bft {
                     if let Ok(proof) = deserialize(&vec_out) {
                         trace!(" wal proof here {:?}", proof);
                         self.proof = proof;
-
-                        if self.height < self.wal_log.current_height {
-                            info!("change height.");
-                            self.height = self.wal_log.current_height;
-                        }
                     }
                 }
                 LOG_TYPE_VERIFIED_PROPOSE => {

--- a/src/core/cita_bft.rs
+++ b/src/core/cita_bft.rs
@@ -1593,6 +1593,7 @@ impl Bft {
                         self.round = 0;
                         self.step = Step::PrecommitAuth;
                         let hi = self.height;
+                        let _ = self.wal_log.set_height(hi);
                         self.save_wal_proof(hi);
                     }
 
@@ -1800,6 +1801,11 @@ impl Bft {
                     if let Ok(proof) = deserialize(&vec_out) {
                         trace!(" wal proof here {:?}", proof);
                         self.proof = proof;
+
+                        if self.height < self.wal_log.current_height {
+                            info!("change height.");
+                            self.height = self.wal_log.current_height;
+                        }
                     }
                 }
                 LOG_TYPE_VERIFIED_PROPOSE => {

--- a/src/core/wal.rs
+++ b/src/core/wal.rs
@@ -26,7 +26,7 @@ const DELETE_FILE_INTERVAL: usize = 3;
 pub struct Wal {
     height_fs: BTreeMap<usize, File>,
     dir: String,
-    current_height: usize,
+    pub current_height: usize,
     ifile: File,
 }
 

--- a/src/core/wal.rs
+++ b/src/core/wal.rs
@@ -26,7 +26,7 @@ const DELETE_FILE_INTERVAL: usize = 3;
 pub struct Wal {
     height_fs: BTreeMap<usize, File>,
     dir: String,
-    pub current_height: usize,
+    current_height: usize,
     ifile: File,
 }
 


### PR DESCRIPTION
1. set wal's height before saving proof, otherwise it will not saved.
2. set current height when got proof from wal, otherwise it will not get pre_hash when got rich status.