### PR TITLE
Fix high cpu usage.

### DIFF
--- a/src/core/cita_bft.rs
+++ b/src/core/cita_bft.rs
@@ -1989,8 +1989,9 @@ impl Bft {
             self.redo_work();
         }
 
+        let wait_secs = ::std::time::Duration::from_secs(60);
         loop {
-            match self.receiver.try_recv() {
+            match self.receiver.recv_timeout(wait_secs) {
                 Ok(BftTurn::Timeout(tm)) => {
                     self.timeout_process(&tm);
                 }


### PR DESCRIPTION
`try_recv` is a non-block method, so this loop cause 100% cpu usage.