### PR TITLE
fix a bug of timer

### DIFF
--- a/src/core/votetime.rs
+++ b/src/core/votetime.rs
@@ -68,8 +68,9 @@ impl WaitTimer {
         loop {
             // take the peek of the min-heap-timer sub now as the sleep time otherwise set timeout as 100
             let timeout = if !timer_heap.is_empty() {
-                if *timer_heap.peek_min().unwrap() > Instant::now() {
-                    *timer_heap.peek_min().unwrap() - Instant::now()
+                let now = Instant::now()
+                if *timer_heap.peek_min().unwrap() > now {
+                    *timer_heap.peek_min().unwrap() - now
                 } else {
                     Duration::new(0, 0)
                 }


### PR DESCRIPTION
A bug might cause instant later than self by the timer min peek is extremely close to `Instant::now()`.