### PR TITLE
Update crate for Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cita-bft"
 version = "0.1.0"
 authors = ["Cryptape Technologies <contact@cryptape.com>"]
+edition = "2018"
 
 [dependencies]
 dotenv = "0.13.0"

--- a/src/core/cita_bft.rs
+++ b/src/core/cita_bft.rs
@@ -42,9 +42,9 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fs;
 use std::time::{Duration, Instant};
 
+use crate::types::{Address, H256};
 use cita_directories::DataPath;
 use hashable::Hashable;
-use crate::types::{Address, H256};
 
 const INIT_HEIGHT: usize = 1;
 const INIT_ROUND: usize = 0;

--- a/src/core/cita_bft.rs
+++ b/src/core/cita_bft.rs
@@ -20,13 +20,13 @@ use std::convert::Into;
 use authority_manage::AuthorityManage;
 use bincode::{deserialize, serialize, Infinite};
 
-use core::params::BftParams;
-use core::voteset::{Proposal, ProposalCollector, VoteCollector, VoteMessage, VoteSet};
+use crate::core::params::BftParams;
+use crate::core::voteset::{Proposal, ProposalCollector, VoteCollector, VoteMessage, VoteSet};
 
-use core::votetime::TimeoutInfo;
-use core::wal::{LogType, Wal};
+use crate::core::votetime::TimeoutInfo;
+use crate::core::wal::{LogType, Wal};
 
-use crypto::{pubkey_to_address, CreateKey, Sign, Signature, SIGNATURE_BYTES_LEN};
+use crate::crypto::{pubkey_to_address, CreateKey, Sign, Signature, SIGNATURE_BYTES_LEN};
 use engine::{unix_now, AsMillis, EngineError, Mismatch};
 use libproto::blockchain::{Block, BlockTxs, BlockWithProof, CompactBlock, RichStatus};
 use libproto::consensus::{
@@ -44,7 +44,7 @@ use std::time::{Duration, Instant};
 
 use cita_directories::DataPath;
 use hashable::Hashable;
-use types::{Address, H256};
+use crate::types::{Address, H256};
 
 const INIT_HEIGHT: usize = 1;
 const INIT_ROUND: usize = 0;

--- a/src/core/params.rs
+++ b/src/core/params.rs
@@ -17,12 +17,12 @@
 
 use super::ntp::Ntp;
 use crate::crypto::{PrivKey, Signer};
+use crate::types::clean_0x;
 use std::cell::Cell;
 use std::fs::File;
 use std::io::Read;
 use std::str::FromStr;
 use std::time::Duration;
-use crate::types::clean_0x;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {

--- a/src/core/params.rs
+++ b/src/core/params.rs
@@ -16,13 +16,13 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::ntp::Ntp;
-use crypto::{PrivKey, Signer};
+use crate::crypto::{PrivKey, Signer};
 use std::cell::Cell;
 use std::fs::File;
 use std::io::Read;
 use std::str::FromStr;
 use std::time::Duration;
-use types::clean_0x;
+use crate::types::clean_0x;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {

--- a/src/core/voteset.rs
+++ b/src/core/voteset.rs
@@ -17,13 +17,13 @@
 
 use super::Step;
 use bincode::{serialize, Infinite};
-use crypto::{pubkey_to_address, Sign, Signature};
+use crate::crypto::{pubkey_to_address, Sign, Signature};
 use hashable::Hashable;
 use libproto::blockchain::{Block, CompactBlock};
 use libproto::TryFrom;
 use lru_cache::LruCache;
 use std::collections::HashMap;
-use types::{Address, H256};
+use crate::types::{Address, H256};
 
 // height -> round collector
 #[derive(Debug)]

--- a/src/core/voteset.rs
+++ b/src/core/voteset.rs
@@ -16,14 +16,14 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::Step;
-use bincode::{serialize, Infinite};
 use crate::crypto::{pubkey_to_address, Sign, Signature};
+use crate::types::{Address, H256};
+use bincode::{serialize, Infinite};
 use hashable::Hashable;
 use libproto::blockchain::{Block, CompactBlock};
 use libproto::TryFrom;
 use lru_cache::LruCache;
 use std::collections::HashMap;
-use crate::types::{Address, H256};
 
 // height -> round collector
 #[derive(Debug)]

--- a/src/core/votetime.rs
+++ b/src/core/votetime.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use core::cita_bft::{BftTurn, Step};
+use crate::core::cita_bft::{BftTurn, Step};
 use min_max_heap::MinMaxHeap;
 use pubsub::channel::{Receiver, Sender};
 use std::collections::HashMap;

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,9 +76,9 @@ use pubsub::channel;
 use std::thread;
 
 mod core;
-use core::cita_bft::{Bft, BftTurn};
-use core::params::{BftParams, Config, PrivateKey};
-use core::votetime::WaitTimer;
+use crate::core::cita_bft::{Bft, BftTurn};
+use crate::core::params::{BftParams, Config, PrivateKey};
+use crate::core::votetime::WaitTimer;
 use cpuprofiler::PROFILER;
 use libproto::router::{MsgType, RoutingKey, SubModules};
 use pubsub::start_pubsub;


### PR DESCRIPTION
Run 'cargo fix --edition' to update crate for Rust 2018.
Run 'cargo fmt' to format code