### PR TITLE
bump to 20.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 dist: xenial
 language: rust
+rust:
+- 1.39.0
+- stable
+
 addons:
   apt:
     packages:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "cita-bft"
-version = "1.0.0"
+version = "20.2.0"
 dependencies = [
  "authority_manage 0.1.0 (git+https://github.com/citahub/cita-common.git?branch=develop)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cita-bft"
-version = "1.0.0"
+version = "20.2.0"
 authors = ["Rivtower Technologies <contact@rivtower.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,7 @@ use std::env;
 
 use util::build_info::gen_build_info;
 
-const VERSION: &str = "1.0.0";
+const VERSION: &str = "20.2.0";
 
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();


### PR DESCRIPTION
```shell
$ cita-bft --version
cita-bft 20.2.0-c25d21d4
(rustc 1.39.0-unknown-2019-11-04)
```